### PR TITLE
update dependencies, fix css-sass.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 node_modules/
 .DS_Store
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install enb-sass --save
 * *String* **target** contains target file name. Default: `?.css`
 * *String* **filesTarget** contains file masks, according to which a list of source files is created. Default: `?.files`.
 * *Array* **sourceSuffixes** Files suffixes that will be used. Default: `css`
-* *Object* **sass** `node-sass` options. Read more: https://github.com/sass/node-sass#options. Default: default `node-sass` options.
+* *Object* **sass** `sass` options. Read more: [SharedOptions](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions), [FileOptions](https://sass-lang.com/documentation/js-api/interfaces/LegacyFileOptions), [StringOptions](https://sass-lang.com/documentation/js-api/interfaces/LegacyStringOptions). Default: default `sass` options.
 
 
 ## Usage
@@ -39,7 +39,7 @@ nodeConfig.addTech([
 ]);
 ```
 
-#### Use `node-sass` [compression](https://github.com/sass/node-sass#outputstyle) and [debug mode](https://github.com/sass/node-sass#sourcecomments)
+#### Use `sass` [compression](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions)
 
 ```javascript
 nodeConfig.addTech([
@@ -48,14 +48,13 @@ nodeConfig.addTech([
     target: '?.css',
     sourceSuffixes: ['scss'],
     sass: {
-      outputStyle: 'compressed',
-      sourceComments: true
+      outputStyle: 'compressed'
     }
   }
 ]);
 ```
 
-#### Collecting ie and ie8 css/scss files with `node-sass` [compression](https://github.com/sass/node-sass#outputstyle) and [debug mode](https://github.com/sass/node-sass#sourcecomments)
+#### Collecting ie and ie8 css/scss files with `sass` [compression](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions)
 
 ```javascript
 nodeConfig.addTech([
@@ -64,8 +63,7 @@ nodeConfig.addTech([
     target: '?.css',
     sourceSuffixes: ['css', 'scss', 'ie.css', 'ie.scss', 'ie8.css', 'ie8.scss'],
     sass: {
-      outputStyle: 'compressed',
-      sourceComments: true
+      outputStyle: 'compressed'
     }
   }
 ]);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [enb](https://github.com/enb-make/enb)-sass [![npm version](https://img.shields.io/badge/npm-v1.0.1-blue.svg)](https://www.npmjs.com/package/enb-sass) [![node-sass supports version](https://img.shields.io/badge/node--sass-3.2.0-orange.svg)](https://github.com/sass/node-sass/tree/v2) [![Build Status](https://travis-ci.org/enb-make/enb-sass.svg?branch=master)](https://travis-ci.org/enb-make/enb-sass) [![Dependency Status](https://david-dm.org/enb-make/enb-sass.svg)](https://david-dm.org/enb-make/enb-sass)
+# [enb](https://github.com/enb-make/enb)-sass [![npm version](https://img.shields.io/badge/npm-v1.0.1-blue.svg)](https://www.npmjs.com/package/enb-sass) [![node-sass supports version](https://img.shields.io/badge/sass-1.49.8-orange.svg)](https://github.com/sass/sass/) [![Build Status](https://travis-ci.org/enb-make/enb-sass.svg?branch=master)](https://travis-ci.org/enb-make/enb-sass) [![Dependency Status](https://david-dm.org/enb-make/enb-sass.svg)](https://david-dm.org/enb-make/enb-sass)
 
 Provides the `node-sass` features for project-builder `enb` (https://github.com/enb-make/enb).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ nodeConfig.addTech([
 ]);
 ```
 
-#### Use `sass` [compression](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions)
+#### Use `sass` [compression](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#outputStyle)
 
 ```javascript
 nodeConfig.addTech([
@@ -54,7 +54,7 @@ nodeConfig.addTech([
 ]);
 ```
 
-#### Collecting ie and ie8 css/scss files with `sass` [compression](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions)
+#### Collecting ie and ie8 css/scss files with `sass` [compression](https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#outputStyle)
 
 ```javascript
 nodeConfig.addTech([

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
         }
     ],
     "dependencies": {
-        "enb": "^1.5.1",
-        "sass": "^1.49.8",
-        "vow": "^0.4.20",
-        "enb-css-preprocessor": "^1.0.0"
+        "enb": "1.5.1",
+        "enb-css-preprocessor": "1.0.0",
+        "sass": "1.49.8",
+        "vow": "0.4.20"
     },
     "engines": {
         "node": ">=0.10"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
             "github-username": "ixax"
         }
     ],
-    "dependencies" : {
-        "enb": "0.15.0",
-        "node-sass": "3.3.3",
-        "vow": "0.4.9",
-        "inherit": "2.2.2"
+    "dependencies": {
+        "enb": "^1.5.1",
+        "sass": "^1.49.8",
+        "vow": "^0.4.20",
+        "enb-css-preprocessor": "^1.0.0"
     },
     "engines": {
         "node": ">=0.10"

--- a/techs/css-sass.js
+++ b/techs/css-sass.js
@@ -11,14 +11,17 @@ Logger = new Logger();
 module.exports = require('enb/lib/build-flow').create()
     .name('enb-sass')
     .target('target', '?.css')
-    .defineOption('sass', {}) // https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions
+    // https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions
+    // https://sass-lang.com/documentation/js-api/interfaces/LegacyFileOptions
+    // https://sass-lang.com/documentation/js-api/interfaces/LegacyStringOptions
+    .defineOption('sass', {}) 
     .useFileList(['css', 'scss'])
     .builder(function (sourceFiles) {
         var _this = this;
         var deferred = Vow.defer();
         var sassSettings = {
             includePaths: [],
-            data: '',
+            data: '', 
             ..._this._options.sass
         };
         var errorLogging = {

--- a/techs/css-sass.js
+++ b/techs/css-sass.js
@@ -11,14 +11,15 @@ Logger = new Logger();
 module.exports = require('enb/lib/build-flow').create()
     .name('enb-sass')
     .target('target', '?.css')
-    .defineOption('sass', {}) // https://github.com/sass/node-sass#options
+    .defineOption('sass', {}) // https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions
     .useFileList(['css', 'scss'])
     .builder(function (sourceFiles) {
         var _this = this;
         var deferred = Vow.defer();
         var sassSettings = {
             includePaths: [],
-            data: ''
+            data: '',
+            ..._this._options.sass
         };
         var errorLogging = {
             enabled: true,
@@ -65,7 +66,7 @@ module.exports = require('enb/lib/build-flow').create()
                     deferred.resolve(cssResult);
                 } catch (ex) {
                     ex = ex instanceof Error ? ex : JSON.parse(ex);
-                    var lines = sassSettings.data.split('\n') || [];
+                    var lines = sassSettings.data.split('\n');
                     var errorCtx = lines.slice(ex.line - errorLogging.offsetLines, ex.line).concat(
                         '^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
                         lines.slice(ex.line + 1, ex.line + errorLogging.offsetLines + 1)

--- a/techs/css-sass.js
+++ b/techs/css-sass.js
@@ -1,7 +1,6 @@
-var sass = require('node-sass');
+var sass = require('sass');
 var Vow = require('vow');
-var inherit = require('inherit');
-var CssPreprocessor = require('enb/lib/preprocess/css-preprocessor');
+var CssPreprocessor = require('enb-css-preprocessor');
 var vowFs = require('enb/lib/fs/async-fs');
 var path = require('path');
 var util = require('util');
@@ -17,10 +16,10 @@ module.exports = require('enb/lib/build-flow').create()
     .builder(function (sourceFiles) {
         var _this = this;
         var deferred = Vow.defer();
-        var sassSettings = inherit({
+        var sassSettings = {
             includePaths: [],
             data: ''
-        }, this._sass);
+        };
         var errorLogging = {
             enabled: true,
             offsetLines: 5
@@ -66,8 +65,7 @@ module.exports = require('enb/lib/build-flow').create()
                     deferred.resolve(cssResult);
                 } catch (ex) {
                     ex = ex instanceof Error ? ex : JSON.parse(ex);
-
-                    var lines = sassSettings.data.split('\n');
+                    var lines = sassSettings.data.split('\n') || [];
                     var errorCtx = lines.slice(ex.line - errorLogging.offsetLines, ex.line).concat(
                         '^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
                         lines.slice(ex.line + 1, ex.line + errorLogging.offsetLines + 1)


### PR DESCRIPTION
Hi,

Fixed package for new NodeJs
Replaced `node-sass` on `sass` (now `npm install` going faster)
Remove `inherit` dependencie
Add `enb-css-preprocessor` instead `enb`

Let up version of the package after pull-request.

Thanks)